### PR TITLE
Update actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Get the cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache
         with:
                  path: ~/.julia


### PR DESCRIPTION
The action/cache v2 is deprecated and will stop being supported on 2025-03-01.

For more information see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down.