### PR TITLE
Add proper imgCIF imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,18 @@ jobs:
           repository: COMCIFS/cif_core
           path: cif-dictionaries/cif_core
 
+      - name: Check out the multiblock coreCIF dictionary
+        uses: actions/checkout@v6
+        with:
+          repository: COMCIFS/cif_multiblock
+          path: cif-dictionaries/cif_multiblock
+
+      - name: Check out the DDLm imgCIF dictionary
+        uses: actions/checkout@v6
+        with:
+            repository: COMCIFS/imgCIF
+            path: cif-dictionaries/imgCIF
+
       - name: Run dictionary validity checks
         uses: COMCIFS/dictionary_check_action@main
         id: ddlm_check

--- a/draft_new_items.dic
+++ b/draft_new_items.dic
@@ -9,8 +9,8 @@ data_DRAFT_NEW_ITEMS
 
     _dictionary.title            DRAFT_NEW_ITEMS
     _dictionary.class            Instance
-    _dictionary.version          0.0.10
-    _dictionary.date             2025-03-24
+    _dictionary.version          0.0.11-dev
+    _dictionary.date             2026-05-06
     _dictionary.uri
       https://raw.githubusercontent.com/COMCIFS/cif_ed/main/draft_new_items.dic
     _dictionary.ddl_conformance  4.2.0
@@ -199,4 +199,11 @@ save_
        handled in a cif_img.dic context or else elaborated with more
        precise definitions and indications where relevant only to
        electron diffraction.
+;
+         0.0.11-dev               2026-05-06
+;
+       # Please update the date above and describe the change below until
+       # ready for the next release
+
+       Initialised new development version.
 ;

--- a/draft_new_items.dic
+++ b/draft_new_items.dic
@@ -48,8 +48,8 @@ save_DRAFT_NEW_ITEMS_HEAD
     _import.get
         [
          {'dupl':Ignore
-          'file':https://github.com/COMCIFS/imgCIF/blob/master/cif_img.dic
-          'mode':Full  'save':HEAD}
+          'file':cif_img.dic
+          'mode':Full  'save':CIF_IMG_HEAD}
         ]
 
 save_


### PR DESCRIPTION
This PR changes the imgCIF import statement in `draft_new_items.dic` so that it could be properly handled by the GitHub actions checks.

I am unsure if @nautolycus plans to continue development in this  repository, but I created this PR just in case while the modifications to the GitHub actions system are still fresh on my mind.